### PR TITLE
NullReferenceException in IsTransient.

### DIFF
--- a/src/Foxlabs.Domain.Abstractions/AggregateRoot.cs
+++ b/src/Foxlabs.Domain.Abstractions/AggregateRoot.cs
@@ -35,7 +35,8 @@ namespace FoxLabs.Domain
     {
         private List<IDomainEvent<TKey>> _domainEvents;
 
-        protected AggregateRoot() { }
+        protected AggregateRoot()
+            : base() { }
 
         protected AggregateRoot(TKey id)
             : base(id)

--- a/src/Foxlabs.Domain.Abstractions/Entity.cs
+++ b/src/Foxlabs.Domain.Abstractions/Entity.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace FoxLabs.Domain
 {
@@ -42,7 +41,7 @@ namespace FoxLabs.Domain
         /// <value>
         /// <c>True</c> if the entity is not-persisted, otherwise <c>false</c>.
         /// </value>
-        public bool IsTransient => Id.Equals(default);
+        public bool IsTransient => Id?.Equals(default) ?? true;
 
         /// <inheritdoc />
         public override bool Equals(object obj)
@@ -79,7 +78,7 @@ namespace FoxLabs.Domain
             {
                 if (!_requestedHashCode.HasValue)
                 {
-                    _requestedHashCode = this.Id.GetHashCode() ^ 31; // XOR for random distribution (http://blogs.msdn.com/b/ericlippert/archive/2011/02/28/guidelines-and-rules-for-gethashcode.aspx)
+                    _requestedHashCode = Id.GetHashCode() ^ 31; // XOR for random distribution (http://blogs.msdn.com/b/ericlippert/archive/2011/02/28/guidelines-and-rules-for-gethashcode.aspx)
                 }
 
                 return _requestedHashCode.Value;

--- a/src/Foxlabs.Domain.Abstractions/FoxLabs.Domain.Abstractions.csproj
+++ b/src/Foxlabs.Domain.Abstractions/FoxLabs.Domain.Abstractions.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageId>FoxLabs.Domain.Abstractions</PackageId>
-    <Version>1.0.9.2</Version>
+    <Version>1.0.10.0</Version>
     <Authors>Brandon Dobbie</Authors>
     <Company></Company>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Description>Provides a lightweight framework for building Domain-Driven (DDD) applications, using MediatR as a base for exposing eventing. Contact support@fox-labs.io for support or feature requests.</Description>
-    <Copyright>© 2022 - Brandon Dobbie</Copyright>
+    <Copyright>© 2024 - Brandon Dobbie</Copyright>
     <PackageProjectUrl>https://github.com/InariTheFox/FoxLabs.Domain</PackageProjectUrl>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/InariTheFox/FoxLabs.Domain</RepositoryUrl>


### PR DESCRIPTION
Resolved the issue where the IsTransient property of Entity<T> causes a NullReferenceException when an Id hasn't been set (ie: is transient), due to the Equals() method being called against the null Id property. Fixed issues with the AggregateRoot class not calling the base() constructor.

Additionally bumped the .NET version to .NET 8.0 and copyright dates. New version is now 1.0.10.0.